### PR TITLE
Fix bug in RefreshToken constructor

### DIFF
--- a/backend/src/main/java/com/chalmers/atas/security/refreshtoken/RefreshToken.java
+++ b/backend/src/main/java/com/chalmers/atas/security/refreshtoken/RefreshToken.java
@@ -48,7 +48,6 @@ public class RefreshToken {
             Instant createdAt
     ) {
         RefreshToken refreshToken = new RefreshToken();
-        refreshToken.tokenId = UUID.randomUUID();
         refreshToken.user = user;
         refreshToken.tokenHash = tokenHash;
         refreshToken.expiresAt = expiresAt;


### PR DESCRIPTION
Fixed `tokenId` was being assigned in
`RefreshToken#of()` which hibernate
didn't like.