### PR TITLE
add more constraints and prefs

### DIFF
--- a/backend/src/main/java/com/chalmers/atas/config/DataInitializer.java
+++ b/backend/src/main/java/com/chalmers/atas/config/DataInitializer.java
@@ -877,5 +877,77 @@ public class DataInitializer {
                 "We are going to have our first meeting in the course, to make this easier for everyone, " +
                         "we can meet at lunch Monday 12-13, if anyone can’t make it please contact me asap.",
                 true));
+
+
+
+
+        // STA888 Course
+        // Users
+        User olivia = User.of(
+                "oli@student.test.se",
+                passwordEncoder.encode("olivia123"),
+                "Olívia",
+                User.UserType.TA
+                );
+        userRepository.save(olivia);
+
+        User zephyrus = User.of(
+                "zep@student.test.se",
+                passwordEncoder.encode("zephyrus123"),
+                "Zephyrus",
+                User.UserType.TA
+                );
+        userRepository.save(zephyrus);
+
+        // Course
+        Course sta888 = Course.of(
+                "STA888",
+                sebastiaanCR,
+                "STARS",
+                true,
+                true,
+                LocalDate.of(2026, 3, 23),
+                LocalDate.of(2026, 6, 6)
+        );
+        courseRepository.save(sta888);
+
+        // CRCourseAssignments
+        crCourseAssignmentRepository.save(CRCourseAssignment.of(
+                sebastiaanCR,
+                sta888,
+                CourseAssignmentStatus.OWNER
+        ));
+
+        // TACourseAssignment
+
+        TACourseAssignment oliTAAssignment = TACourseAssignment.of(
+                olivia,
+                sta888,
+                CourseAssignmentStatus.INVITED,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+        taCourseAssignmentRepository.save(oliTAAssignment);
+
+        TACourseAssignment zepTAAssignment = TACourseAssignment.of(
+                zephyrus,
+                sta888,
+                CourseAssignmentStatus.INVITED,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+        taCourseAssignmentRepository.save(zepTAAssignment);
+        
+
     }
 }

--- a/backend/src/main/java/com/chalmers/atas/config/DataInitializer.java
+++ b/backend/src/main/java/com/chalmers/atas/config/DataInitializer.java
@@ -800,8 +800,8 @@ public class DataInitializer {
                 phoAssignment,
                 ConstraintType.HARD,
                 LocalDateTime.of(2026, 03, 16, 8, 00),
-                LocalDateTime.of(2026, 01, 21, 17, 00),
-                true
+                LocalDateTime.of(2026, 03, 21, 17, 00),
+                false
         ));
 
         taCourseSessionConstraintRepository.save(TACourseSessionConstraint.of(

--- a/backend/src/main/java/com/chalmers/atas/config/DataInitializer.java
+++ b/backend/src/main/java/com/chalmers/atas/config/DataInitializer.java
@@ -502,16 +502,44 @@ public class DataInitializer {
         taCourseSessionConstraintRepository.save(TACourseSessionConstraint.of(
                 yakAssignment,
                 ConstraintType.HARD,
+                LocalDateTime.of(2026, 01, 20, 8, 00),
+                LocalDateTime.of(2026, 01, 20, 12, 00),
+                true
+        ));
+        taCourseSessionConstraintRepository.save(TACourseSessionConstraint.of(
+                yakAssignment,
+                ConstraintType.HARD,
                 LocalDateTime.of(2026, 01, 21, 10, 00),
                 LocalDateTime.of(2026, 01, 21, 17, 00),
                 true
+        ));
+        taCourseSessionConstraintRepository.save(TACourseSessionConstraint.of(
+                yakAssignment,
+                ConstraintType.HARD,
+                LocalDateTime.of(2026, 01, 23, 8, 00),
+                LocalDateTime.of(2026, 01, 23, 12, 00),
+                true
+        ));
+        taCourseSessionConstraintRepository.save(TACourseSessionConstraint.of(
+                yakAssignment,
+                ConstraintType.HARD,
+                LocalDateTime.of(2026, 03, 16, 8, 00),
+                LocalDateTime.of(2026, 03, 21, 17, 00),
+                false
         ));
 
         taCourseSessionConstraintRepository.save(TACourseSessionConstraint.of(
                 levAssignment,
                 ConstraintType.HARD,
-                LocalDateTime.of(2026, 01, 19, 13, 00),
+                LocalDateTime.of(2026, 01, 19, 10, 00),
                 LocalDateTime.of(2026, 01, 19, 15, 00),
+                true
+        ));
+        taCourseSessionConstraintRepository.save(TACourseSessionConstraint.of(
+                levAssignment,
+                ConstraintType.HARD,
+                LocalDateTime.of(2026, 01, 21, 13, 00),
+                LocalDateTime.of(2026, 01, 21, 15, 00),
                 true
         ));
         taCourseSessionConstraintRepository.save(TACourseSessionConstraint.of(
@@ -555,6 +583,48 @@ public class DataInitializer {
                 LocalDateTime.of(2026, 01, 23, 8, 00),
                 LocalDateTime.of(2026, 01, 23, 10, 00),
                 true
+        ));
+        taCourseSessionConstraintRepository.save(TACourseSessionConstraint.of(
+                levAssignment,
+                ConstraintType.SOFT,
+                LocalDateTime.of(2026, 03, 16, 8, 00),
+                LocalDateTime.of(2026, 03, 16, 17, 00),
+                false
+        ));
+        taCourseSessionConstraintRepository.save(TACourseSessionConstraint.of(
+                levAssignment,
+                ConstraintType.SOFT,
+                LocalDateTime.of(2026, 03, 17, 8, 00),
+                LocalDateTime.of(2026, 03, 17, 17, 00),
+                false
+        ));
+        taCourseSessionConstraintRepository.save(TACourseSessionConstraint.of(
+                levAssignment,
+                ConstraintType.SOFT,
+                LocalDateTime.of(2026, 03, 18, 8, 00),
+                LocalDateTime.of(2026, 03, 18, 17, 00),
+                false
+        ));
+        taCourseSessionConstraintRepository.save(TACourseSessionConstraint.of(
+                levAssignment,
+                ConstraintType.SOFT,
+                LocalDateTime.of(2026, 03, 19, 8, 00),
+                LocalDateTime.of(2026, 03, 19, 17, 00),
+                false
+        ));
+        taCourseSessionConstraintRepository.save(TACourseSessionConstraint.of(
+                levAssignment,
+                ConstraintType.SOFT,
+                LocalDateTime.of(2026, 03, 20, 8, 00),
+                LocalDateTime.of(2026, 03, 20, 17, 00),
+                false
+        ));
+        taCourseSessionConstraintRepository.save(TACourseSessionConstraint.of(
+                levAssignment,
+                ConstraintType.SOFT,
+                LocalDateTime.of(2026, 03, 21, 8, 00),
+                LocalDateTime.of(2026, 03, 21, 17, 00),
+                false
         ));
 
         taCourseSessionConstraintRepository.save(TACourseSessionConstraint.of(
@@ -606,6 +676,48 @@ public class DataInitializer {
                 LocalDateTime.of(2026, 01, 23, 17, 00),
                 true
         ));
+        taCourseSessionConstraintRepository.save(TACourseSessionConstraint.of(
+                albAssignment,
+                ConstraintType.SOFT,
+                LocalDateTime.of(2026, 03, 16, 8, 00),
+                LocalDateTime.of(2026, 03, 16, 17, 00),
+                false
+        ));
+        taCourseSessionConstraintRepository.save(TACourseSessionConstraint.of(
+                albAssignment,
+                ConstraintType.SOFT,
+                LocalDateTime.of(2026, 03, 17, 8, 00),
+                LocalDateTime.of(2026, 03, 17, 17, 00),
+                false
+        ));
+        taCourseSessionConstraintRepository.save(TACourseSessionConstraint.of(
+                albAssignment,
+                ConstraintType.SOFT,
+                LocalDateTime.of(2026, 03, 18, 8, 00),
+                LocalDateTime.of(2026, 03, 18, 17, 00),
+                false
+        ));
+        taCourseSessionConstraintRepository.save(TACourseSessionConstraint.of(
+                albAssignment,
+                ConstraintType.HARD,
+                LocalDateTime.of(2026, 03, 19, 8, 00),
+                LocalDateTime.of(2026, 03, 19, 17, 00),
+                false
+        ));
+        taCourseSessionConstraintRepository.save(TACourseSessionConstraint.of(
+                albAssignment,
+                ConstraintType.HARD,
+                LocalDateTime.of(2026, 03, 20, 8, 00),
+                LocalDateTime.of(2026, 03, 20, 17, 00),
+                false
+        ));
+        taCourseSessionConstraintRepository.save(TACourseSessionConstraint.of(
+                albAssignment,
+                ConstraintType.SOFT,
+                LocalDateTime.of(2026, 03, 21, 8, 00),
+                LocalDateTime.of(2026, 03, 21, 17, 00),
+                false
+        ));
 
         taCourseSessionConstraintRepository.save(TACourseSessionConstraint.of(
                 phoAssignment,
@@ -624,8 +736,22 @@ public class DataInitializer {
         taCourseSessionConstraintRepository.save(TACourseSessionConstraint.of(
                 phoAssignment,
                 ConstraintType.HARD,
+                LocalDateTime.of(2026, 01, 19, 13, 00),
+                LocalDateTime.of(2026, 01, 19, 15, 00),
+                true
+        ));
+        taCourseSessionConstraintRepository.save(TACourseSessionConstraint.of(
+                phoAssignment,
+                ConstraintType.HARD,
                 LocalDateTime.of(2026, 01, 20, 13, 00),
                 LocalDateTime.of(2026, 01, 20, 15, 00),
+                true
+        ));
+        taCourseSessionConstraintRepository.save(TACourseSessionConstraint.of(
+                phoAssignment,
+                ConstraintType.HARD,
+                LocalDateTime.of(2026, 01, 21, 13, 00),
+                LocalDateTime.of(2026, 01, 21, 15, 00),
                 true
         ));
         taCourseSessionConstraintRepository.save(TACourseSessionConstraint.of(
@@ -670,6 +796,13 @@ public class DataInitializer {
                 LocalDateTime.of(2026, 01, 23, 17, 00),
                 true
         ));
+        taCourseSessionConstraintRepository.save(TACourseSessionConstraint.of(
+                phoAssignment,
+                ConstraintType.HARD,
+                LocalDateTime.of(2026, 03, 16, 8, 00),
+                LocalDateTime.of(2026, 01, 21, 17, 00),
+                true
+        ));
 
         taCourseSessionConstraintRepository.save(TACourseSessionConstraint.of(
                 noeAssignment,
@@ -691,6 +824,48 @@ public class DataInitializer {
                 LocalDateTime.of(2026, 01, 23, 8, 00),
                 LocalDateTime.of(2026, 01, 23, 12, 00),
                 true
+        ));
+        taCourseSessionConstraintRepository.save(TACourseSessionConstraint.of(
+                noeAssignment,
+                ConstraintType.SOFT,
+                LocalDateTime.of(2026, 03, 16, 8, 00),
+                LocalDateTime.of(2026, 03, 16, 17, 00),
+                false
+        ));
+        taCourseSessionConstraintRepository.save(TACourseSessionConstraint.of(
+                noeAssignment,
+                ConstraintType.SOFT,
+                LocalDateTime.of(2026, 03, 17, 8, 00),
+                LocalDateTime.of(2026, 03, 17, 17, 00),
+                false
+        ));
+        taCourseSessionConstraintRepository.save(TACourseSessionConstraint.of(
+                noeAssignment,
+                ConstraintType.SOFT,
+                LocalDateTime.of(2026, 03, 18, 8, 00),
+                LocalDateTime.of(2026, 03, 18, 17, 00),
+                false
+        ));
+        taCourseSessionConstraintRepository.save(TACourseSessionConstraint.of(
+                noeAssignment,
+                ConstraintType.SOFT,
+                LocalDateTime.of(2026, 03, 19, 8, 00),
+                LocalDateTime.of(2026, 03, 19, 17, 00),
+                false
+        ));
+        taCourseSessionConstraintRepository.save(TACourseSessionConstraint.of(
+                noeAssignment,
+                ConstraintType.SOFT,
+                LocalDateTime.of(2026, 03, 20, 8, 00),
+                LocalDateTime.of(2026, 03, 20, 17, 00),
+                false
+        ));
+        taCourseSessionConstraintRepository.save(TACourseSessionConstraint.of(
+                noeAssignment,
+                ConstraintType.SOFT,
+                LocalDateTime.of(2026, 03, 21, 8, 00),
+                LocalDateTime.of(2026, 03, 21, 17, 00),
+                false
         ));
 
         // Announcements

--- a/backend/src/main/java/com/chalmers/atas/domain/tacourseassignment/TACourseAssignmentService.java
+++ b/backend/src/main/java/com/chalmers/atas/domain/tacourseassignment/TACourseAssignmentService.java
@@ -1,6 +1,8 @@
 package com.chalmers.atas.domain.tacourseassignment;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -81,6 +83,34 @@ public class TACourseAssignmentService {
             );
         }
 
+        Integer updatedMinHours = minHours != null ? minHours : taCourseAssignment.getMinHours();
+        Integer updatedMaxHours = maxHours != null ? maxHours : taCourseAssignment.getMaxHours();
+        CourseSessionType updatedPreference1 =
+            sessionTypePreference1 != null ? sessionTypePreference1 : taCourseAssignment.getSessionTypePreference1();
+        CourseSessionType updatedPreference2 =
+            sessionTypePreference2 != null ? sessionTypePreference2 : taCourseAssignment.getSessionTypePreference2();
+        CourseSessionType updatedPreference3 =
+            sessionTypePreference3 != null ? sessionTypePreference3 : taCourseAssignment.getSessionTypePreference3();
+        CourseSessionType updatedPreference4 =
+            sessionTypePreference4 != null ? sessionTypePreference4 : taCourseAssignment.getSessionTypePreference4();
+
+        if (updatedMinHours != null && updatedMaxHours != null && updatedMaxHours < updatedMinHours) {
+            return TransactionalResult.rollbackFor(
+                ErrorCode.BAD_REQUEST.toError("maxHours cannot be less than minHours")
+            );
+        }
+
+        if (hasDuplicatePreferences(
+                updatedPreference1,
+                updatedPreference2,
+                updatedPreference3,
+                updatedPreference4
+        )) {
+            return TransactionalResult.rollbackFor(
+                ErrorCode.BAD_REQUEST.toError("session type preferences must be unique")
+            );
+        }
+
         if (minHours != null) {
             taCourseAssignment.setMinHours(minHours);
         }
@@ -104,6 +134,16 @@ public class TACourseAssignmentService {
         }
 
         return TransactionalResult.ok(taCourseAssignmentRepository.save(taCourseAssignment));
+    }
+
+    private boolean hasDuplicatePreferences(CourseSessionType... preferences) {
+        Set<CourseSessionType> seenPreferences = new HashSet<>();
+        for (CourseSessionType preference : preferences) {
+            if (preference != null && !seenPreferences.add(preference)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public Result<List<TACourseAssignment>> getCourseAssignments(Course course){

--- a/backend/src/test/java/com/chalmers/atas/algorithmtest/AlgorithmTestBase.java
+++ b/backend/src/test/java/com/chalmers/atas/algorithmtest/AlgorithmTestBase.java
@@ -322,15 +322,38 @@ public abstract class AlgorithmTestBase {
                 LocalTime.of(12, 0)
         ));
         constraints.addAll(weeklyHardConstraints(
+                yakovId, 
+                LocalDate.of(2026, 1, 20), 
+                LocalTime.of(8, 0), 
+                LocalTime.of(12, 0)
+        ));
+        constraints.addAll(weeklyHardConstraints(
                 yakovId,
                 LocalDate.of(2026, 1, 21),
                 LocalTime.of(10, 0),
                 LocalTime.of(17, 0)
         ));
+        constraints.addAll(weeklyHardConstraints(
+                yakovId,
+                LocalDate.of(2026, 1, 23),
+                LocalTime.of(8, 0),
+                LocalTime.of(12, 0)
+        ));
+        constraints.add(hardConstraint(
+                yakovId,
+                LocalDateTime.of(2026, 3, 16, 8, 0),
+                LocalDateTime.of(2026, 3, 21, 17, 0)
+        ));
 
         constraints.addAll(weeklyHardConstraints(
                 leviId,
                 LocalDate.of(2026, 1, 19),
+                LocalTime.of(10, 0),
+                LocalTime.of(15, 0)
+        ));
+        constraints.addAll(weeklyHardConstraints(
+                leviId,
+                LocalDate.of(2026, 1, 21),
                 LocalTime.of(13, 0),
                 LocalTime.of(15, 0)
         ));
@@ -363,6 +386,17 @@ public abstract class AlgorithmTestBase {
                 LocalDateTime.of(2026, 1, 30, 8, 0),
                 LocalDateTime.of(2026, 1, 30, 10, 0)
         ));
+        constraints.add(hardConstraint(
+                albericId,
+                LocalDateTime.of(2026, 3, 19, 8, 0),
+                LocalDateTime.of(2026, 3, 19, 17, 0)
+        ));
+        constraints.add(hardConstraint(
+                albericId,
+                LocalDateTime.of(2026, 3, 20, 8, 0),
+                LocalDateTime.of(2026, 3, 20, 17, 0)
+        ));
+
 
         constraints.addAll(weeklyHardConstraints(
                 phoebeId,
@@ -378,7 +412,19 @@ public abstract class AlgorithmTestBase {
         ));
         constraints.addAll(weeklyHardConstraints(
                 phoebeId,
+                LocalDate.of(2026, 1, 19),
+                LocalTime.of(13, 0),
+                LocalTime.of(15, 0)
+        ));
+        constraints.addAll(weeklyHardConstraints(
+                phoebeId,
                 LocalDate.of(2026, 1, 20),
+                LocalTime.of(13, 0),
+                LocalTime.of(15, 0)
+        ));
+        constraints.addAll(weeklyHardConstraints(
+                phoebeId,
+                LocalDate.of(2026, 1, 21),
                 LocalTime.of(13, 0),
                 LocalTime.of(15, 0)
         ));
@@ -387,6 +433,11 @@ public abstract class AlgorithmTestBase {
                 LocalDate.of(2026, 1, 23),
                 LocalTime.of(13, 0),
                 LocalTime.of(15, 0)
+        ));
+        constraints.add(hardConstraint(
+                phoebeId,
+                LocalDateTime.of(2026, 3, 16, 8, 0),
+                LocalDateTime.of(2026, 3, 21, 17, 0)
         ));
 
         constraints.addAll(weeklyHardConstraints(
@@ -449,6 +500,42 @@ public abstract class AlgorithmTestBase {
                 LocalTime.of(10, 0),
                 DEFAULT_SOFT_WEIGHT
         ));
+        constraints.add(softConstraint(
+                leviId,
+                LocalDateTime.of(2026, 3, 16, 8, 0),
+                LocalDateTime.of(2026, 3, 16, 17, 0),
+                DEFAULT_SOFT_WEIGHT
+        ));
+        constraints.add(softConstraint(
+                leviId,
+                LocalDateTime.of(2026, 3, 17, 8, 0),
+                LocalDateTime.of(2026, 3, 17, 17, 0),
+                DEFAULT_SOFT_WEIGHT
+        ));
+        constraints.add(softConstraint(
+                leviId,
+                LocalDateTime.of(2026, 3, 18, 8, 0),
+                LocalDateTime.of(2026, 3, 18, 17, 0),
+                DEFAULT_SOFT_WEIGHT
+        ));
+        constraints.add(softConstraint(
+                leviId,
+                LocalDateTime.of(2026, 3, 19, 8, 0),
+                LocalDateTime.of(2026, 3, 19, 17, 0),
+                DEFAULT_SOFT_WEIGHT
+        ));
+        constraints.add(softConstraint(
+                leviId,
+                LocalDateTime.of(2026, 3, 20, 8, 0),
+                LocalDateTime.of(2026, 3, 20, 17, 0),
+                DEFAULT_SOFT_WEIGHT
+        ));
+        constraints.add(softConstraint(
+                leviId,
+                LocalDateTime.of(2026, 3, 21, 8, 0),
+                LocalDateTime.of(2026, 3, 21, 17, 0),
+                DEFAULT_SOFT_WEIGHT
+        ));
 
         constraints.addAll(weeklySoftConstraints(
                 albericId,
@@ -469,6 +556,30 @@ public abstract class AlgorithmTestBase {
                 LocalDate.of(2026, 1, 23),
                 LocalTime.of(13, 0),
                 LocalTime.of(17, 0),
+                DEFAULT_SOFT_WEIGHT
+        ));
+        constraints.add(softConstraint(
+                albericId,
+                LocalDateTime.of(2026, 3, 16, 8, 0),
+                LocalDateTime.of(2026, 3, 16, 17, 0),
+                DEFAULT_SOFT_WEIGHT
+        ));
+        constraints.add(softConstraint(
+                albericId,
+                LocalDateTime.of(2026, 3, 17, 8, 0),
+                LocalDateTime.of(2026, 3, 17, 17, 0),
+                DEFAULT_SOFT_WEIGHT
+        ));
+        constraints.add(softConstraint(
+                albericId,
+                LocalDateTime.of(2026, 3, 18, 8, 0),
+                LocalDateTime.of(2026, 3, 18, 17, 0),
+                DEFAULT_SOFT_WEIGHT
+        ));
+        constraints.add(softConstraint(
+                albericId,
+                LocalDateTime.of(2026, 3, 21, 8, 0),
+                LocalDateTime.of(2026, 3, 21, 17, 0),
                 DEFAULT_SOFT_WEIGHT
         ));
 
@@ -505,6 +616,42 @@ public abstract class AlgorithmTestBase {
                 LocalDate.of(2026, 1, 23),
                 LocalTime.of(15, 0),
                 LocalTime.of(17, 0),
+                DEFAULT_SOFT_WEIGHT
+        ));
+        constraints.add(softConstraint(
+                noelleId,
+                LocalDateTime.of(2026, 3, 16, 8, 0),
+                LocalDateTime.of(2026, 3, 16, 17, 0),
+                DEFAULT_SOFT_WEIGHT
+        ));
+        constraints.add(softConstraint(
+                noelleId,
+                LocalDateTime.of(2026, 3, 17, 8, 0),
+                LocalDateTime.of(2026, 3, 17, 17, 0),
+                DEFAULT_SOFT_WEIGHT
+        ));
+        constraints.add(softConstraint(
+                noelleId,
+                LocalDateTime.of(2026, 3, 18, 8, 0),
+                LocalDateTime.of(2026, 3, 18, 17, 0),
+                DEFAULT_SOFT_WEIGHT
+        ));
+        constraints.add(softConstraint(
+                noelleId,
+                LocalDateTime.of(2026, 3, 19, 8, 0),
+                LocalDateTime.of(2026, 3, 19, 17, 0),
+                DEFAULT_SOFT_WEIGHT
+        ));
+        constraints.add(softConstraint(
+                noelleId,
+                LocalDateTime.of(2026, 3, 20, 8, 0),
+                LocalDateTime.of(2026, 3, 20, 17, 0),
+                DEFAULT_SOFT_WEIGHT
+        ));
+        constraints.add(softConstraint(
+                noelleId,
+                LocalDateTime.of(2026, 3, 21, 8, 0),
+                LocalDateTime.of(2026, 3, 21, 17, 0),
                 DEFAULT_SOFT_WEIGHT
         ));
 


### PR DESCRIPTION
2nd and 4th year TAs have now two courses that they attend instead of one which is the more natural way of curriculum studies at Chalmers, this was missed while designing the data. Also, each TA now have their own constraint and preferences regarding their own exams on the exam week (where grading sessions take place). Thus, this PR adds more constraints to each TA in the data initlizer.